### PR TITLE
Use the provider factory method for typeahead for #23

### DIFF
--- a/src/app/lib/ipaas-data-mapper/data.mapper.module.ts
+++ b/src/app/lib/ipaas-data-mapper/data.mapper.module.ts
@@ -35,7 +35,7 @@ import { DocumentDefinitionComponent } from './components/document.definition.co
 
 import { MappingFieldDetailComponent } from './components/mapping.field.detail.component';
 import { MappingFieldActionComponent } from './components/mapping.field.action.component';
-import { MappingDetailComponent, MappingDetailHeaderComponent, 
+import { MappingDetailComponent, MappingDetailHeaderComponent,
 	MappingFieldSectionComponent } from './components/mapping.detail.component';
 import { MappingSelectionComponent } from './components/mapping.selection.component';
 
@@ -59,11 +59,11 @@ export { DataMapperAppComponent } from './components/data.mapper.app.component';
 
 
 @NgModule({
-	imports: [ 
-		CommonModule, 
-		HttpModule, 
-		FormsModule, 
-		TypeaheadModule
+	imports: [
+		CommonModule,
+		HttpModule,
+		FormsModule,
+		TypeaheadModule.forRoot()
 	],
 	declarations: [
 		DataMapperAppComponent,


### PR DESCRIPTION
Only way I could find to fix #23, could be a bug in how ng2-bootstrap has their typeahead module set up, but they're on to angular 4.x now.